### PR TITLE
Add path_to_file_list feature

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
In the third line of the path_to_file_list function, several modifications were made to the code. First, since the function returns lines, the variable li was changed to lines to correctly return the file's contents. Additionally, the mode for opening the file was changed from open(path, 'w') to open(path, 'r') because the file's contents need to be read. Finally, since the original code did not actually read the file contents, open(path, 'r').read() was used to read the entire file and store its contents in the lines variable.