### PR TITLE
Fix main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n') #잘못된 변수명 li를 line으로 변경, file open option을 w->r로 수정,'\n'을 기준으로 나눠서 읽도록 수정
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"' # German -> English
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,18 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file) #파일명을 english_file -> german_file로 수정
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
+        #mid eng start ger start -> start eng mid ger end 로 순서 수정
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f: #file open option을 r->w로 수정
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n') #file을 출력하게끔 수정
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +44,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path) #train_file_list_to_json -> path_to_file_list
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list) #path_to_file_list -> train_file_list_to_json
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
line5. 잘못된 변수명 li를 line으로 변경, file open option을 w->r로 수정,'\n'을 기준으로 나눠서 읽도록 수정
-li를 변수명으로 설정하여 제대로된 리턴값을 반환하지 못했음, option을 w로 설정하여 파일을 읽는 기능을 수행하지 못했음, 기준을 설정하지 않아 파일을 제대로 읽어드리고 있지 못했음.
line20. template_start의 내용을 German에서 English로 수정
-문제에서 의도한 출력이 아니였음
line28. 첫번째 파일 변수명을 english_file -> german_file로 수정
-변수명을 제대로 설정해주지 않아 논리적 오류가 났음
line30. 파일을 합쳐주는 순서를 mid eng start ger start -> start eng mid ger end 로 순서 수정
-문제의 의도대로 답을 출력하고 있지 않았음.
line37. file open option을 r->w로 수정
-option을 r로 설정하여 파일 쓰기 기능을 수행하지 못헀음.
line39. file을 입력하도록 수정
-'\n'만 입력하고있었음.
line47. train_file_list_to_json -> path_to_file_list로 함수 수정
-잘못된 함수를 부르고 있었음
line49. path_to_file_list -> train_file_list_to_json로 함수 수정
-잘못된 함수를 부르고 있었음