### PR TITLE
make corrections

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
5) 파일을 읽어와야하기 때문에 "r" 모드로 파일을 열어야 하고, '\n'을 기준으로 끊어 읽어 와서 리스트에 저장해야합니다. 또 변수명을 lines 로 고쳐 올바르게 리턴되도록 하였습니다.

20) concated.json 템플릿의 처음은 "English" 이므로 고쳤습니다.

28) english_file과 german_file의 처리내용을 둘 다 english_file 변수에 저장하면 덮어쓰여지기 때문에, german_file로 변수명을 변경하였습니다.

30) 템플릿의 순서가 mid -> start -> start로 설정되어 있으므로, start->mid->end로 수정하였습니다.

36, 38) merge한 내용을 파일에 작성해야 하므로 "w"가 아닌 "r"모드로 파일을 열어야 하며, f.write 함수내에 작성할 파일 내용이 포함되어 있지 않습니다.

46) 코드를 처음 실행하고 german.txt 을 읽어 리스트로 저장을 먼저 해야하기 때문에, train_file_list_to_json 함수가 아닌 path_to_file_list 함수를 호출해야합니다.

48) 앞에서 텍스트파일을 리스트로 변환하는 과정을 이미 끝냈으므로 처리된 파일을 train_file_list_to_json 함수를 통해 합쳐야 합니다.
