### PR TITLE
Fixed bugs in main.py for concatenating files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 seo-jeongyeon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
a. path_to_file_list에서 li = open(path, 'w')를 lines = open(path, 'r').read().split('\n')로 고쳤다.
b. 원래 코드에서 파일을 여는 모드가 'w'(쓰기 모드)로 설정되어 있었는데 이것은 새로 파일을 쓰거나 기존 파일을 덮어쓰는 용도로 사용되며, 파일을 읽는 데 사용할 수 없다. 파일 내용을 읽지 않고 빈 파일로 덮어씌우기 때문에 파일이 열릴 때 기존 내용이 삭제된다. 이는 path_to_file_list 함수의 의도인 "파일의 각 줄을 읽어서 리스트로 반환" 기능을 수행하지 못하게 한다. 따라서 파일을 읽기 모드로 열어서 기존 파일의 내용을 그대로 유지한 채 읽어올 수 있도록 수정했다. 
