### PR TITLE
correct template

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"' # change template start
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -27,7 +27,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         english_file = process_file(english_file)
         english_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end) # change processed file format
     return processed_file_list
 
 


### PR DESCRIPTION
On line 20, I modified template_start = '{\"German\":\"' to template_start = '{\"English\":\"'. This ensures that the output follows the format {"English":"(some English sentence)". The original code outputs `{"German":"(English sentence)"`.

On line 30, I modified the code from processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) to the correct format. Now, it ensures that after template_start, the English sentence is followed by template_mid, the German sentence, and then template_end. This aligns with the proper format requirements. The original code creates a completely disorganized format.