### PR TITLE
Fix main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,32 +10,31 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +42,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
This is wrong for following lines. 
1. `li = open(path, 'w')`     
we have to return that which named lines. 
2. `file = file.replace('\\', '\\')`   
inpropal replacement
3. `template_start = '{\"German\":\"'`   
template_start must be English not German
4. `english_file = process_file(german_file)`   
the processing result of german must be german. 
5. `processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)` 
the order of template is wrong
6. `with open(path, 'r') as f: for file in file_list: f.write('\n')`
have to open with 'w' and write file
7. `german_file_list = path_to_file_list(german_path) processed_file_list = train_file_list_to_json(english_file_list, german_file_list)`
inprorpal function is applied

So I fixed each problem to
1. `lines = open(path, 'r').read().split('\n')`
2. `file = file.replace('\\', '\\\\')`
3. `template_start = '{\"English\":\"'`
4. `german_file = process_file(german_file)`
5. `processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)`
6. `with open(path, 'w') as f: for file in file_list: f.write(file + '\n')`
7. `german_file_list = path_to_file_list(german_path) processed_file_list = train_file_list_to_json(english_file_list, german_file_list)`