### PR TITLE
Fix path_to_file_lsit func lines split

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
i changed the line 5 like this:
li = open(path, 'w') -> lines = open(path, 'r').read().split('\n')
we have to read  a file and return a list of lines in the file. but init version opens the file with write mode.