### PR TITLE
Made corrections to the code

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,32 +10,30 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +41,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
# Format

- Line
- Code
- Explanation

### Line 5
`li = open(path, 'w')` -> `lines = open(path, 'r').read().split('\n')`
The file is opened in write ('w') mode, which erases its contents, but the function's intent seems to be reading lines from the file. The change opens the file in read ('r') mode, reads its contents, and splits it into lines for further processing.

### Line 13
`file = file.replace('\\', '\\')` -> `file = file.replace('\\', '\\\\')`
The original code attempts to replace a backslash with itself, which is redundant. The modification ensures that single backslashes in file paths are escaped properly to become double backslashes, which is necessary in JSON strings or Windows paths.

### Line 20
`template_start = '{\"German\":\"'` -> `template_start = '{\"English\":\"'`
The change reflects the intent of starting the JSON string with an English key instead of a German key, aligning with the logic of including both English and German file data.

### Line 28
`english_file = process_file(german_file)` -> `german_file = process_file(german_file)`
The original incorrectly overwrites the english_file variable with the processed german_file. The corrected version ensures the German file is processed into its own variable.

### Line 30
`processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)` -> `processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)`
The original concatenation order of the template parts was incorrect. The modified code properly constructs the JSON string by placing template_start for the English file, template_mid for the German file, and closing the JSON string with template_end.

### Line 36
`with open(path, 'r') as f:` -> `with open(path, 'w') as f:`
The function write_file_list aims to write to a file, but opening the file in read ('r') mode would cause an error. Changing the mode to write ('w') allows the function to output the file list correctly.

### Line 38
`f.write('\n')` -> `f.write(file + '\n')`
The original code only writes a newline for each file, but the intended functionality is to write the file's contents followed by a newline. The modification ensures the correct data is written to the file.

### Line 46
`german_file_list = train_file_list_to_json(german_path)` -> `german_file_list = path_to_file_list(german_path)`
The function train_file_list_to_json expects two file lists (English and German) as input, but the original incorrectly uses it to read a file. The correct function for this operation is path_to_file_list.

### Line 48
`processed_file_list = path_to_file_list(english_file_list, german_file_list)` -> `processed_file_list = train_file_list_to_json(english_file_list, german_file_list)`
The original incorrectly uses path_to_file_list, which reads a single file, instead of train_file_list_to_json, which processes two lists into a JSON-compatible format. The modification aligns with the intended functionality.