### PR TITLE
Fix variable names and file modes

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -33,9 +33,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'


### PR DESCRIPTION
function path_to_file_list:
- line 5
  - Changed the variable name from li to lines to ensure the return statement works correctly.
  - Although I could have changed lines to li, I chose to rename it for clearer variable meaning.
  - Also, since the function reads data rather than writes it, I changed the file mode to 'r' to open the file in read-only mode.

function write_file_list:
- line 36
  - Since this is a function that writes to a file, I changed the file mode to 'w' to set it to write-only mode.
- line 38
  - The for loop iterates over file, but the code was only writing '\n' to the file. To write the contents of file, I modified it to f.write(file + '\n').

Thank you for reviewing this PR.