### PR TITLE
changed path_to_file_list function

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
I changed line 5 in path_to_file_list, and there are two reasons.
1. Variable name is incorrect. This function defines 'li' variable but returns 'lines' variable. So I changed the variable name 'li' to 'lines'.
2. This function is for reading lines in the file and returning as a list of lines, but it's opening the file for writing. So I changed it to open the file for reading, and also splited the files by '\n'