### PR TITLE
fixed the code in path_to_file_list, now it will return a list of lines

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
Old version: 
def path_to_file_list(path: str) -> List[str]:
    """Reads a file and returns a list of lines in the file"""
    li = open(path, 'w')
    return lines
    
New version: 
def path_to_file_list(path: str) -> List[str]:
    """Reads a file and returns a list of lines in the file"""
    lines = open(path, 'r').read().splitlines()
    return lines

I changed the line "li = open(path, 'w')" in original code, where it was using 'w' mode, which is writing mode. In this mode, the program will not be able to read data from the file as described in the comment. Therefore, I changed this line to "lines = open(path, 'r').read().splitlines()" in order to read data from the file correctly and split into a list divided by lines. 