### PR TITLE
Fixed JSON output issue in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    lines = open(path, 'r').read().split('\n')
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -10,14 +10,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
1. Line 5
>수정 전:
>```python
>li = open(path, 'w')
>```
>수정 후:
>```python
>lines = open(path, 'r').read().split('\n')
>```
>수정 내용: 
>파일을 쓰기 모드로 열면 파일을 읽는 대신 덮어쓰는 현상 발생. 따라서 파일을 읽고 줄 단위로 분리하여 리스트로 반환하도록 수정.

2. Line 13
>수정 전:
>```python
>file = file.replace('\\', '\\')
>```
>수정 후:
>```python
>file = file.replace('\\', '\\\\')
>```
>수정 내용:
>전처리에 아무 영향을 미치지 않던 코드를 올바르게 수정.

3. Line 20
>수정 전:
>```python
>template_start = '{\"German\":\"'
>```
>수정 후:
>```python
>template_start = '{\"English\":\"'
>```
>수정 내용:
>영어 문장을 독일어라고 표기하던 오류 수정.

4. Line 28-30
>수정 전:
>```python
>english_file = process_file(german_file)
>
>processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
>```
>수정 후:
>```python
>german_file = process_file(german_file)
>
>processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
>```
>수정 내용:
>english_file에 german_file 데이터를 처리하던 오류 수정. 템플릿 순서를 올바르게 수정.

5. Line 36-38
>수정 전:
>```python
>with open(path, 'r') as f:
>    for file in file_list:
>        f.write('\n')
>```
>수정 후:
>```python
>with open(path, 'w') as f:
>    for file in file_list:
>        f.write(file + '\n')
>```
>수정 내용:
>파일 작성을 위해 읽기 모드로 열던 오류를 쓰기 모드로 열도록 수정. 각 문자열을 줄바꿈으로 구분하여 저장하도록 수정.

6. Line 46-48
>수정 전:
>```python
>german_file_list = train_file_list_to_json(german_path)
>
>processed_file_list = path_to_file_list(english_file_list, german_file_list)
>```
>수정 후:
>```python
>german_file_list = path_to_file_list(german_path)
>
>processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
>```
>수정 내용: 
>잘못된 함수 호출 및 인수 전달 문제를 올바르게 수정.