### PR TITLE
path_to_file_list is committed

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f:
+	    lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
### **_Line 5:_**
li = open(path, 'w') ->
with open(path, 'r') as f:
	lines = f.read().splitlines()

The open(path, 'w') mode is incorrect because the function seems to be reading a file, not to be writing to it. With corrected version it reads its contents, and then splits into lines.