### PR TITLE
Train file list to json

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -26,9 +26,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f:
+	    lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:


### PR DESCRIPTION
### _**Line 20:**_
template_start = '{\"German\":\"' -> template_start = '{\"English\":\"'

It incorrectly used "German" twice, this would lead to invalid JSON. Updated version correctly matches "English" and "German" fields.


### **_Line 28:_**
english_file = process_file(german_file) ->
german_file = process_file(german_file)

The original code contains a logical error in assigning process_file() result to the wrong variable. Updated version now processes german_file independently without overwriting english_file.


### **_Line 30:_**
processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) ->
processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)

Misplacement of template components. Also added template_end, the corrected code ensures correct and valid structure.