### PR TITLE
Modify main.py to successfully generate the intended JSON file.

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,9 +34,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f :
+        lines = f.read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:

--- a/main.py
+++ b/main.py
@@ -11,14 +11,14 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     # Preprocess unwanted characters
     def process_file(file):
         if '\\' in file:
-            file = file.replace('\\', '\\')
+            file = file.replace('\\', '\\\\')
         if '/' or '"' in file:
             file = file.replace('/', '\\/')
             file = file.replace('"', '\\"')
         return file
 
     # Template for json file
-    template_start = '{\"German\":\"'
+    template_start = '{\"English\":\"'
     template_mid = '\",\"German\":\"'
     template_end = '\"}'
 
@@ -26,9 +26,9 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 

--- a/main.py
+++ b/main.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
     write_file_list(processed_file_list, path+'concated.json')


### PR DESCRIPTION
1. path_to_file_list Function fix (path_fix)
When using `with open` to read a file, it is appropriate to use the 'r' mode.  
To return a `List[str]` as a list of lines from the file, `splitlines()` should be used.  
To return `lines`, it must first be properly defined.

2. train_file_list_to_json Function fix (train_fix)
`file.replace('\\', '\\')` is unnecessary and a typo.  
`english_file` is overwritten by itself and then again by `german_file`, resulting in an incorrect JSON file.  
The assignment and application order of the `template` variables are incorrect.

3. write_file_list Function fix (write_fix)
When using `with open` to write to a file, it is appropriate to use the 'w' mode.  
Using UTF-8 encoding allows handling characters beyond the German alphabet with ease.  
The use of `f.write('\n')` only writes an empty line, making it redundant. Instead, `f.write(file + '\n')` is more appropriate.

4. main Block fix (main_block_fix)
It is correct to use `path_to_file_list` to read `german.txt`.  
`processed_file_list` should use the `train_file_list_to_json` function.
