### PR TITLE
2022310421 main.py fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    li = open(path, 'r').read().splitlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
@@ -25,17 +25,17 @@ def train_file_list_to_json(english_file_list: List[str], german_file_list: List
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
     return processed_file_list
 
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
+            f.write(file + '\n')
             
 if __name__ == "__main__":
     path = './'


### PR DESCRIPTION
## What lines of the codes have been changed
1) li = open(path, 'w')  -> li = open(path, 'r').read().splitlines()
2) english_file = process_file(german_file) -> german_file = process_file(german_file)
3) processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)
4)     with open(path, 'r') as f:
        for file in file_list:
            f.write('\n')
->     with open(path, 'w') as f:
        for file in file_list:
            f.write(file + '\n')

## Why these codes are wrong
1) The description announced to read the files, not to write.
2) The value "english_file" has been overwritten.
3) The order is wrong.
4) The description announced to write the files, not to read. Also, the text contents to be read had been missing.