### PR TITLE
Fix main.py to generate concated.json

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,3 +45,4 @@ if __name__ == "__main__":
 
     write_file_list(processed_file_list, path + 'concated.json')
 
+

--- a/main.py
+++ b/main.py
@@ -2,49 +2,46 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
+    with open(path, 'r') as f:
+        lines = f.readlines()
     return lines
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
-    """Converts two lists of file paths into a list of json strings"""
-    # Preprocess unwanted characters
+    """Converts two lists of file paths into a list of JSON strings"""
     def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
+        file = file.replace('\\', '\\\\')
+        file = file.replace('/', '\\/')
+        file = file.replace('"', '\\"')
         return file
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
+    template_start = '{"English":"'
+    template_mid = '","German":"'
+    template_end = '"}'
 
-    # Can this be working?
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
-        english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        english_file = process_file(english_file.strip())
+        german_file = process_file(german_file.strip())
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        json_string = template_start + english_file + template_mid + german_file + template_end
+        processed_file_list.append(json_string)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
-            
+            f.write(file + '\n')
+
 if __name__ == "__main__":
     path = './'
     german_path = './german.txt'
     english_path = './english.txt'
 
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    write_file_list(processed_file_list, path + 'concated.json')
+


### PR DESCRIPTION
path_to_file_list 함수의 파일 열기 모드를 'w'에서 'r'로 변경하고 한 줄씩 읽도록 수정
'w'모드로 파일을 열면 파일을 덮어쓰게 되어 읽기 작업이 불가능하기 때문

write_file_list 함수의 파일 열기 모드를 'r'에서 'w'로 변경. 'r' 모드는 파일 쓰기를 지원하지 않으므로 데이터를 저장할 수 없음

__main__에서 함수 호출과 인자 전달 방식 수정. 
german_file_list = train_file_list_to_json(german_path) -> german_file_list = path_to_file_list(german_path)
processed_file_list = path_to_file_list(english_file_list, german_file_list) -> processed_file_list = train_file_list_to_json(english_file_list, german_file_list)

train_file_list_to_json함수에서 JSON 생성 로직 수정. 템플릿 작성 로직이 잘못되어 문자열 생성에 실패했음.
line31 processed_file_list.append(template_mid + english_file + template_start + german_file + template_start) -> processed_file_list.append(template_start + english_file + template_mid + german_file + template_end)