### PR TITLE
Fixed main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,49 +2,47 @@ from typing import List
 
 def path_to_file_list(path: str) -> List[str]:
     """Reads a file and returns a list of lines in the file"""
-    li = open(path, 'w')
-    return lines
+    with open(path, 'r') as f:
+        lines = f.readlines()
+    return [line.strip() for line in lines]
 
 def train_file_list_to_json(english_file_list: List[str], german_file_list: List[str]) -> List[str]:
     """Converts two lists of file paths into a list of json strings"""
     # Preprocess unwanted characters
-    def process_file(file):
-        if '\\' in file:
-            file = file.replace('\\', '\\')
-        if '/' or '"' in file:
-            file = file.replace('/', '\\/')
-            file = file.replace('"', '\\"')
+    def process_file(file: str) -> str:
+        file = file.replace('\\', '\\\\')  # Escape backslashes
+        file = file.replace('/', '\\/')    # Escape forward slashes
+        file = file.replace('"', '\\"')   # Escape double quotes
         return file
 
-    # Template for json file
-    template_start = '{\"German\":\"'
-    template_mid = '\",\"German\":\"'
-    template_end = '\"}'
-
-    # Can this be working?
+    # Template for json format
     processed_file_list = []
     for english_file, german_file in zip(english_file_list, german_file_list):
         english_file = process_file(english_file)
-        english_file = process_file(german_file)
+        german_file = process_file(german_file)
 
-        processed_file_list.append(template_mid + english_file + template_start + german_file + template_start)
+        json_entry = f'{{"English":"{english_file}","German":"{german_file}"}}'
+        processed_file_list.append(json_entry)
     return processed_file_list
-
 
 def write_file_list(file_list: List[str], path: str) -> None:
     """Writes a list of strings to a file, each string on a new line"""
-    with open(path, 'r') as f:
+    with open(path, 'w') as f:
         for file in file_list:
-            f.write('\n')
-            
+            f.write(file + '\n')
+
 if __name__ == "__main__":
     path = './'
     german_path = './german.txt'
     english_path = './english.txt'
 
+    # Read input files
     english_file_list = path_to_file_list(english_path)
-    german_file_list = train_file_list_to_json(german_path)
+    german_file_list = path_to_file_list(german_path)
 
-    processed_file_list = path_to_file_list(english_file_list, german_file_list)
+    # Convert to JSON format
+    processed_file_list = train_file_list_to_json(english_file_list, german_file_list)
 
-    write_file_list(processed_file_list, path+'concated.json')
+    # Write output to concated.json
+    write_file_list(processed_file_list, path + 'concated.json')
+


### PR DESCRIPTION
**1. File Opening Modes**

The path_to_file_list function incorrectly opened the file in 'w', preventing it from reading the file. This was corrected to 'r'.

`li = open(path, 'r')  # Corrected file mode to 'r'`
```
    with open(path, 'r') as f:
        lines = f.readlines()
return [line.strip() for line in lines]
```

The write_file_list function also used 'r' instead of 'w' to write data to the output file. 

`with open(path, 'w') as f:  # Corrected file mode to 'w' for writing`

The write_file_list function could not write to the output file because it was opened in 'r' mode instead of 'w' mode.

**2. JSON Formatting**

In the train_file_list_to_json function, the JSON template was incorrect:

- The keys for English and German fields were swapped.
- Special characters were not properly escaped.

```
template_start = '{\"English\":\"'  # Changed 'German' to 'English'
template_mid = '\",\"German\":\"'   # Corrected the 'German' key
```
